### PR TITLE
Check if socket.terminate function exists before calling it

### DIFF
--- a/client.js
+++ b/client.js
@@ -18,7 +18,9 @@ module.exports = function (addr, opts = {}) {
     socket.close()
   })
   stream.destroy = () => {
-    socket.terminate()
+    if (socket.terminate) {
+      socket.terminate()
+    }
   }
   stream.socket = socket
 

--- a/client.js
+++ b/client.js
@@ -20,6 +20,8 @@ module.exports = function (addr, opts = {}) {
   stream.destroy = () => {
     if (socket.terminate) {
       socket.terminate()
+    } else {
+      socket.close()
     }
   }
   stream.socket = socket


### PR DESCRIPTION
Hello 👋 

This PR adds a check if `socket.terminate()` function exists before calling it in the `stream.destroy` callback.

The WebSocket spec doesn't include the `terminate()` function which I suppose is what `ws` module provides. This in turn creates an "terminate is undefined" error in the browser.

Not sure if this is the right fix, but this fixes the problems I've been seeing with it. Happy to revise if needed.