### PR TITLE
Make the duplex transformation more easily usable standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,13 @@ these modules are used internally, to wrap a websocket.
 you probably won't need to touch these,
 but they are documented anyway.
 
-### `require('pull-ws/duplex')(socket, opts?)`
+### `require('pull-ws/duplex')(socket, opts?, req?)`
 
 turn a websocket into a duplex pull stream.
 If provided, `opts` is passed to `pws.sink(socket, opts)`.
+Optionally pass the incoming request as `req` in Node.js to
+populate the stream's `remoteAddress` and `remotePort` from
+the request's socket.
 
 Websockets do not support half open mode.
 [see allowHalfOpen option in net module](
@@ -158,10 +161,6 @@ If you have a protocol that assumes halfOpen connections, but are using
 a networking protocol like websockets that does not support it, I suggest
 using [pull-goodbye](https://github.com/dominictarr/pull-goodbye) with your
 protocol.
-
-The duplex stream will also contain a copy of the properties from
-the http request that became the websocket. they are `method`, `url`,
-`headers` and `upgrade`.
 
 also exposed at: `var duplex = require('pull-ws')`
 

--- a/client.js
+++ b/client.js
@@ -11,22 +11,7 @@ module.exports = function (addr, opts = {}) {
   const url = wsurl(addr, location)
   const socket = new WebSocket(url, opts.websocket)
 
-  const stream = duplex(socket, opts)
-  stream.remoteAddress = url
-  stream.close = () => new Promise((resolve, reject) => {
-    socket.addEventListener('close', resolve)
-    socket.close()
-  })
-  stream.destroy = () => {
-    if (socket.terminate) {
-      socket.terminate()
-    } else {
-      socket.close()
-    }
-  }
-  stream.socket = socket
-
-  return stream
+  return duplex(socket, opts)
 }
 
 module.exports.connect = module.exports

--- a/server.js
+++ b/server.js
@@ -39,19 +39,11 @@ module.exports = !WebSocket.Server ? null : function (opts, onConnection) {
   proxy(server, 'close')
 
   wsServer.on('connection', function (socket, req) {
-    var stream = ws(socket)
+    var stream = ws(socket, {}, req)
     const addr = wsServer.address()
 
     stream.localAddress = addr.address
     stream.localPort = addr.port
-    stream.remoteAddress = req.socket.remoteAddress
-    stream.remotePort = req.socket.remotePort
-    stream.close = () => new Promise((resolve) => {
-      socket.addEventListener('close', resolve)
-      socket.close()
-    })
-    stream.destroy = () => socket.terminate()
-    stream.socket = socket
 
     emitter.emit('connection', stream, req)
   })

--- a/test/pass-in-server.js
+++ b/test/pass-in-server.js
@@ -15,6 +15,7 @@ tape('simple echo server', async function (t) {
   await server.listen(5678)
 
   const stream = WS.connect('ws://localhost:5678')
+  t.equal(stream.remoteAddress, 'ws://localhost:5678/');
 
   const ary = await pipe(
     [1, 2, 3],


### PR DESCRIPTION
I'm using it-ws to upgrade an existing WebSocket stream manually, instead of getting the stream from it-ws's own server or client.

This is quite possible, but requires manually recreating various bits of logic here, because some stream setup is only done in the server & client, not on the duplex itself. That logic is fairly similar between the server & client anyway, so the duplication here is a bit unncessary.

This PR fixes that, by moving the common stream setup logic from the server & client into the duplex's own setup function. This only affects usage of the duplex, which now includes all the standard properties like `remoteAddress`, `socket`, `close` & `destroy`. Any other usage of the client & server should behave exactly the same as before.

Notably this changes the logic behind the client stream `remoteAddress`, to read it directly from the standard [WebSocket.url](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/url) property, just for simplicity. That wasn't covered by the tests, so I've added a quick assertion here too, which passes with the same value for both the previous version and this new refactored version.