### PR TITLE
fix: only close duplex if open

### DIFF
--- a/src/duplex.ts
+++ b/src/duplex.ts
@@ -44,10 +44,16 @@ export default (socket: WebSocket, options?: DuplexWebSocketOptions): DuplexWebS
     sink: sink(socket, options),
     source: connectedSource,
     connected: async () => await connectedSource.connected(),
-    close: async () => await new Promise<void>((resolve) => {
-      socket.addEventListener('close', () => resolve())
-      socket.close()
-    }),
+    close: async () => {
+      if (socket.readyState === socket.CONNECTING || socket.readyState === socket.OPEN) {
+        await new Promise<void>((resolve) => {
+          socket.addEventListener('close', () => {
+            resolve()
+          })
+          socket.close()
+        })
+      }
+    },
     destroy: () => {
       if (socket.terminate != null) {
         socket.terminate()

--- a/test/duplex.spec.ts
+++ b/test/duplex.spec.ts
@@ -1,0 +1,65 @@
+import { expect } from 'aegir/utils/chai.js'
+import WebSocket from '../src/web-socket.js'
+import drain from 'it-drain'
+import { pipe } from 'it-pipe'
+import wsurl from './helpers/wsurl.js'
+import * as WS from '../src/index.js'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import delay from 'delay'
+
+const endpoint = wsurl + '/echo'
+
+describe('duplex', () => {
+  it('should close if already closed', async () => {
+    const socket = new WebSocket(endpoint)
+    const data = [
+      uint8ArrayFromString('x'),
+      uint8ArrayFromString('y'),
+      uint8ArrayFromString('z')
+    ]
+
+    const duplex = WS.duplex(socket, { closeOnEnd: false })
+
+    await pipe(
+      data,
+      duplex,
+      drain
+    )
+
+    expect(duplex.socket.readyState).to.equal(WebSocket.CLOSED)
+
+    await duplex.close()
+
+    expect(duplex.socket.readyState).to.equal(WebSocket.CLOSED)
+  })
+
+  it('should close if connecting', async () => {
+    const socket = new WebSocket(endpoint)
+    const duplex = WS.duplex(socket, { closeOnEnd: false })
+
+    expect(duplex.socket.readyState).to.equal(WebSocket.CONNECTING)
+
+    await duplex.close()
+
+    expect(duplex.socket.readyState).to.equal(WebSocket.CLOSED)
+  })
+
+  it('should close if open', async () => {
+    const socket = new WebSocket(endpoint)
+    const duplex = WS.duplex(socket, { closeOnEnd: false })
+
+    while (true) {
+      if (duplex.socket.readyState === WebSocket.OPEN) {
+        break
+      }
+
+      await delay(100)
+    }
+
+    expect(duplex.socket.readyState).to.equal(WebSocket.OPEN)
+
+    await duplex.close()
+
+    expect(duplex.socket.readyState).to.equal(WebSocket.CLOSED)
+  })
+})


### PR DESCRIPTION
When closing a websocket we only get a `'close'` event if the socket `readyState` was `CONNECTING` or `OPEN` to start with.

When it's `CLOSED` or `CLOSING` the promise returned from `.close()` never resolves so don't await on a `'close'` event we're never going to receive.