### PR TITLE
fix: emit error events on returned server

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,17 +157,16 @@
   },
   "scripts": {
     "lint": "aegir lint",
-    "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
-    "build": "tsc",
-    "pretest": "npm run build",
-    "test": "aegir test -f ./dist/test",
-    "test:chrome": "npm run test -- -t browser",
-    "test:chrome-webworker": "npm run test -- -t webworker",
-    "test:firefox": "npm run test -- -t browser -- --browser firefox",
-    "test:firefox-webworker": "npm run test -- -t webworker -- --browser firefox",
-    "test:node": "npm run test -- -t node --cov",
-    "test:electron-main": "npm run test -- -t electron-main",
-    "release": "semantic-release"
+    "dep-check": "aegir dep-check",
+    "build": "aegir build",
+    "test": "aegir test",
+    "test:chrome": "aegir test -t browser",
+    "test:chrome-webworker": "aegir test-t webworker",
+    "test:firefox": "aegir test -t browser -- --browser firefox",
+    "test:firefox-webworker": "aegir test -t webworker -- --browser firefox",
+    "test:node": "aegir test -t node --cov",
+    "test:electron-main": "aegir test -t electron-main",
+    "release": "aegir release"
   },
   "dependencies": {
     "event-iterator": "^2.0.0",
@@ -178,7 +177,7 @@
   },
   "devDependencies": {
     "@types/ws": "^8.2.2",
-    "aegir": "^36.1.3",
+    "aegir": "^37.0.15",
     "delay": "^5.0.0",
     "it-all": "^1.0.6",
     "it-drain": "^1.0.5",

--- a/src/server.ts
+++ b/src/server.ts
@@ -83,12 +83,12 @@ export function createServer (opts?: ServerOptions): WebSocketServer {
     const addr = wsServer.address()
 
     if (typeof addr === 'string') {
-      wsServer.emit('error', new Error('Cannot listen on unix sockets'))
+      wss.emit('error', new Error('Cannot listen on unix sockets'))
       return
     }
 
     if (req.socket.remoteAddress == null || req.socket.remotePort == null) {
-      wsServer.emit('error', new Error('Remote connection did not have address and/or port'))
+      wss.emit('error', new Error('Remote connection did not have address and/or port'))
       return
     }
 

--- a/test/close-on-end.spec.ts
+++ b/test/close-on-end.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'aegir/utils/chai.js'
+import { expect } from 'aegir/chai'
 import WebSocket from '../src/web-socket.js'
 import drain from 'it-drain'
 import { pipe } from 'it-pipe'

--- a/test/duplex.spec.ts
+++ b/test/duplex.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'aegir/utils/chai.js'
+import { expect } from 'aegir/chai'
 import WebSocket from '../src/web-socket.js'
 import drain from 'it-drain'
 import { pipe } from 'it-pipe'

--- a/test/echo-inline.spec.ts
+++ b/test/echo-inline.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'aegir/utils/chai.js'
+import { expect } from 'aegir/chai'
 import * as WS from '../src/index.js'
 import ndjson from 'it-ndjson'
 import map from 'it-map'

--- a/test/echo.spec.ts
+++ b/test/echo.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'aegir/utils/chai.js'
+import { expect } from 'aegir/chai'
 import WebSocket from '../src/web-socket.js'
 import * as WS from '../src/index.js'
 import { pipe } from 'it-pipe'

--- a/test/error.spec.ts
+++ b/test/error.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'aegir/utils/chai.js'
+import { expect } from 'aegir/chai'
 import WebSocket from '../src/web-socket.js'
 import { pipe } from 'it-pipe'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'

--- a/test/load.spec.ts
+++ b/test/load.spec.ts
@@ -14,9 +14,9 @@ describe('load', () => {
     // const start = Date.now()
 
     const server = await WS.createServer({
-      onConnection: async function (stream) {
+      onConnection: function (stream) {
         let N = 0
-        await pipe(
+        void pipe(
           stream.source,
           (source) => each(source, val => {
             if (N % 1000 === 0) {
@@ -25,9 +25,10 @@ describe('load', () => {
             N++
           }),
           drain
-        )
+        ).then(async () => {
+          await server.close()
+        })
         // console.log(N, N / ((Date.now() - start) / 1000)) // eslint-disable-line no-console
-        await server.close()
       }
     }).listen(2134)
 

--- a/test/pass-in-server.spec.ts
+++ b/test/pass-in-server.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'aegir/utils/chai.js'
+import { expect } from 'aegir/chai'
 import * as WS from '../src/index.js'
 import ndjson from 'it-ndjson'
 import { pipe } from 'it-pipe'

--- a/test/read.spec.ts
+++ b/test/read.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'aegir/utils/chai.js'
+import { expect } from 'aegir/chai'
 import WebSocket from '../src/web-socket.js'
 import { pipe } from 'it-pipe'
 import all from 'it-all'

--- a/test/server-address.spec.ts
+++ b/test/server-address.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'aegir/utils/chai.js'
+import { expect } from 'aegir/chai'
 import { isNode, isElectronMain } from 'wherearewe'
 import * as WS from '../src/index.js'
 

--- a/test/server-echo.spec.ts
+++ b/test/server-echo.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'aegir/utils/chai.js'
+import { expect } from 'aegir/chai'
 import * as WS from '../src/index.js'
 import ndjson from 'it-ndjson'
 import { pipe } from 'it-pipe'

--- a/test/server-echo.spec.ts
+++ b/test/server-echo.spec.ts
@@ -16,8 +16,8 @@ describe('simple echo server', () => {
 
   it('echoes', async () => {
     const server = WS.createServer({
-      onConnection: async stream => {
-        await pipe(stream, stream)
+      onConnection: stream => {
+        void pipe(stream, stream)
       }
     })
 

--- a/test/ws-url.spec.ts
+++ b/test/ws-url.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'aegir/utils/chai.js'
+import { expect } from 'aegir/chai'
 import wsurl from '../src/ws-url.js'
 
 describe('ws-url', () => {


### PR DESCRIPTION
Sometimes a remote connection has no address and/or port. When that happens emit the error on the returned server rather than the WSServer instance as otherwise the error is unhandled and can crash the process.

Also upgrades aegir to the latest version.