### PR TITLE
fix: add matching export

### DIFF
--- a/src/server.browser.ts
+++ b/src/server.browser.ts
@@ -1,3 +1,5 @@
-export function createServer() {
+import type { ServerOptions, WebSocketServer } from './server.js'
+
+export function createServer (opts?: ServerOptions): WebSocketServer {
   throw new Error('WebSocket Servers cannot run in browsers')
 }

--- a/src/server.browser.ts
+++ b/src/server.browser.ts
@@ -1,2 +1,3 @@
-
-export default null
+export function createServer() {
+  throw new Error('WebSocket Servers cannot run in browsers')
+}


### PR DESCRIPTION
Recent versions of esbuild object most strenuously if you don't export the same symbols from browser overrides as the regular version.

Fixes errors like:

```
ERROR: No matching export in "../../node_modules/it-ws/dist/src/server.browser.js" for import "createServer"
```