### PR TITLE
fix: import server.browser.js for esbuild compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
+      "browser": "./dist/src/index.browser.js",
       "import": "./dist/src/index.js"
     },
     "./client": {

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -1,5 +1,5 @@
 export { default as duplex } from './duplex.js'
 export { default as source } from './source.js'
 export { default as sink } from './sink.js'
-export { createServer } from './server.js'
+export { createServer } from './server.browser.js'
 export { connect } from './client.js'


### PR DESCRIPTION
Issue: https://github.com/paralin/it-ws-issue-20/

Fixes: #20

esbuild index.ts --bundle --platform=browser

Fails with an error importing "events". The server-side code is being imported even when platform=browser.

Esbuild does correctly respect the "browser" portion of package.json as well as the exports section. However, it follows the "." export and tries to bundle dist/src/index.js which imports dist/src/server.js.

Adding a browser import to dist/src/index.browser.js which imports server.browser.js instead of server.js fixes the issue.