### PR TITLE
deps!: update stream types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 node_modules
-.nyc_output
+build
 dist
-coverage
+.docs
+.coverage
+node_modules
 package-lock.json
+yarn.lock
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # it-ws <!-- omit in toc -->
 
 [![codecov](https://img.shields.io/codecov/c/github/alanshaw/it-ws.svg?style=flat-square)](https://codecov.io/gh/alanshaw/it-ws)
-[![CI](https://img.shields.io/github/workflow/status/alanshaw/it-ws/test%20&%20maybe%20release/master?style=flat-square)](https://github.com/alanshaw/it-ws/actions/workflows/js-test-and-release.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/alanshaw/it-ws/js-test-and-release.yml?branch=master\&style=flat-square)](https://github.com/alanshaw/it-ws/actions/workflows/js-test-and-release.yml?query=branch%3Amaster)
 
 > Simple async iterables for websocket client connections
 
 ## Table of contents <!-- omit in toc -->
 
 - [Install](#install)
+  - [Browser `<script>` tag](#browser-script-tag)
 - [Usage](#usage)
   - [Example - client](#example---client)
   - [Example - server](#example---server)
@@ -21,12 +22,20 @@
   - [`import sink from 'it-ws/sink'`](#import-sink-from-it-wssink)
   - [`import source from 'it-ws/source'`](#import-source-from-it-wssource)
 - [License](#license)
-- [Contribute](#contribute)
+- [Contribution](#contribution)
 
 ## Install
 
 ```console
 $ npm i it-ws
+```
+
+### Browser `<script>` tag
+
+Loading this module through a script tag will make it's exports available as `ItWs` in the global namespace.
+
+```html
+<script src="https://unpkg.com/it-ws/dist/index.min.js"></script>
 ```
 
 ## Usage
@@ -259,6 +268,6 @@ Licensed under either of
 - Apache 2.0, ([LICENSE-APACHE](LICENSE-APACHE) / <http://www.apache.org/licenses/LICENSE-2.0>)
 - MIT ([LICENSE-MIT](LICENSE-MIT) / <http://opensource.org/licenses/MIT>)
 
-## Contribute
+## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "files": [
     "src",
-    "dist/src",
+    "dist",
     "!dist/test",
     "!**/*.tsbuildinfo"
   ],
@@ -176,26 +176,27 @@
     "test:firefox-webworker": "aegir test -t webworker -- --browser firefox",
     "test:node": "aegir test -t node --cov",
     "test:electron-main": "aegir test -t electron-main",
-    "release": "aegir release"
+    "release": "aegir release",
+    "docs": "aegir docs"
   },
   "dependencies": {
     "event-iterator": "^2.0.0",
     "iso-url": "^1.1.2",
-    "it-stream-types": "^1.0.2",
+    "it-stream-types": "^2.0.1",
     "uint8arrays": "^4.0.2",
     "ws": "^8.4.0"
   },
   "devDependencies": {
     "@types/ws": "^8.2.2",
-    "aegir": "^37.0.15",
+    "aegir": "^38.1.8",
     "delay": "^5.0.0",
-    "it-all": "^2.0.0",
-    "it-drain": "^2.0.0",
-    "it-foreach": "^1.0.0",
+    "it-all": "^3.0.1",
+    "it-drain": "^3.0.1",
+    "it-foreach": "^2.0.2",
     "it-goodbye": "^4.0.0",
-    "it-map": "^2.0.0",
+    "it-map": "^3.0.2",
     "it-ndjson": "^1.0.0",
-    "it-pipe": "^2.0.3",
+    "it-pipe": "^3.0.1",
     "p-defer": "^4.0.0",
     "wherearewe": "^2.0.1",
     "wsurl": "^1.0.0"

--- a/src/duplex.ts
+++ b/src/duplex.ts
@@ -2,9 +2,9 @@ import source from './source.js'
 import sink from './sink.js'
 import type WebSocket from './web-socket.js'
 import type { SinkOptions } from './sink.js'
-import type { Duplex } from 'it-stream-types'
+import type { Duplex, Source } from 'it-stream-types'
 
-export interface DuplexWebSocket extends Duplex<Uint8Array, Uint8Array, Promise<void>> {
+export interface DuplexWebSocket extends Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>, Promise<void>> {
   connected: () => Promise<void>
   localAddress?: string
   localPort?: number
@@ -43,7 +43,7 @@ export default (socket: WebSocket, options?: DuplexWebSocketOptions): DuplexWebS
   const duplex: DuplexWebSocket = {
     sink: sink(socket, options),
     source: connectedSource,
-    connected: async () => await connectedSource.connected(),
+    connected: async () => { await connectedSource.connected() },
     close: async () => {
       if (socket.readyState === socket.CONNECTING || socket.readyState === socket.OPEN) {
         await new Promise<void>((resolve) => {

--- a/src/ready.ts
+++ b/src/ready.ts
@@ -1,6 +1,6 @@
 import type { ErrorEvent, WebSocket } from 'ws'
 
-export default (socket: WebSocket) => {
+export default async (socket: WebSocket): Promise<void> => {
   // if the socket is closing or closed, return end
   if (socket.readyState >= 2) {
     throw new Error('socket closed')
@@ -11,18 +11,18 @@ export default (socket: WebSocket) => {
     return
   }
 
-  return new Promise<void>((resolve, reject) => {
-    function cleanup () {
+  await new Promise<void>((resolve, reject) => {
+    function cleanup (): void {
       socket.removeEventListener('open', handleOpen)
       socket.removeEventListener('error', handleErr)
     }
 
-    function handleOpen () {
+    function handleOpen (): void {
       cleanup()
       resolve()
     }
 
-    function handleErr (event: ErrorEvent) {
+    function handleErr (event: ErrorEvent): void {
       cleanup()
       reject(event.error ?? new Error(`connect ECONNREFUSED ${socket.url}`))
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,26 +29,26 @@ class Server extends EventEmitter {
     opts = opts ?? {}
     this.server = server
     this.wsServer = new WSServer({
-      server: server,
+      server,
       perMessageDeflate: false,
       verifyClient: opts.verifyClient
     })
     this.wsServer.on('connection', this.onWsServerConnection.bind(this))
   }
 
-  async listen (addrInfo: { port: number } | number) {
+  async listen (addrInfo: { port: number } | number): Promise<WebSocketServer> {
     return await new Promise<WebSocketServer>((resolve, reject) => {
-      this.wsServer.once('error', (e) => reject(e))
-      this.wsServer.once('listening', () => resolve(this))
+      this.wsServer.once('error', (e) => { reject(e) })
+      this.wsServer.once('listening', () => { resolve(this) })
       this.server.listen(typeof addrInfo === 'number' ? addrInfo : addrInfo.port)
     })
   }
 
-  async close () {
-    return await new Promise<void>((resolve, reject) => {
+  async close (): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
       this.server.close((err) => {
         if (err != null) {
-          return reject(err)
+          reject(err); return
         }
 
         resolve()
@@ -56,11 +56,11 @@ class Server extends EventEmitter {
     })
   }
 
-  address () {
+  address (): string | AddressInfo | null {
     return this.server.address()
   }
 
-  onWsServerConnection (socket: WebSocket, req: http.IncomingMessage) {
+  onWsServerConnection (socket: WebSocket, req: http.IncomingMessage): void {
     const addr = this.wsServer.address()
 
     if (typeof addr === 'string') {
@@ -96,7 +96,7 @@ export function createServer (opts?: ServerOptions): WebSocketServer {
     wss.on('connection', opts.onConnection)
   }
 
-  function proxy (server: http.Server, event: string) {
+  function proxy (server: http.Server, event: string): http.Server {
     return server.on(event, (...args: any[]) => {
       wss.emit(event, ...args)
     })

--- a/src/ws-url.ts
+++ b/src/ws-url.ts
@@ -3,4 +3,4 @@ import { relative } from 'iso-url'
 const map = { http: 'ws', https: 'wss' }
 const def = 'ws'
 
-export default (url: string, location: string | Partial<Location>) => relative(url, location, map, def)
+export default (url: string, location: string | Partial<Location>): string => relative(url, location, map, def)

--- a/test/echo-inline.spec.ts
+++ b/test/echo-inline.spec.ts
@@ -23,7 +23,7 @@ describe('simple echo server', () => {
       [1, 2, 3],
       // need a delay, because otherwise ws hangs up wrong.
       // otherwise use pull-goodbye.
-      (source) => map(source, async val => await new Promise(resolve => setTimeout(() => resolve(val), 10))),
+      (source) => map(source, async val => await new Promise(resolve => setTimeout(() => { resolve(val) }, 10))),
       (source) => map(ndjson.stringify(source), str => uint8ArrayFromString(str)),
       WS.connect('ws://localhost:5678'),
       ndjson.parse,

--- a/test/echo.spec.ts
+++ b/test/echo.spec.ts
@@ -78,13 +78,15 @@ describe('echo', () => {
       pws,
       goodbye({
         source: expected,
-        sink: async source => await pipe(
-          source,
-          (source) => each(source, (value) => {
-            expect(value).to.equalBytes(expected.shift())
-          }),
-          drain
-        )
+        sink: async source => {
+          await pipe(
+            source,
+            (source) => each(source, (value) => {
+              expect(value).to.equalBytes(expected.shift())
+            }),
+            drain
+          )
+        }
       }),
       pws
     )

--- a/test/helpers/server.ts
+++ b/test/helpers/server.ts
@@ -3,7 +3,7 @@ import type { WebSocket } from 'ws'
 
 const port = parseInt(process.env.PORT ?? '3000', 10)
 
-export function createTestServer () {
+export function createTestServer (): WebSocketServer {
   const routes: Record<string, (ws: WebSocket) => void> = {
     '/read': function (ws: WebSocket) {
       const values = ['a', 'b', 'c', 'd']
@@ -24,7 +24,7 @@ export function createTestServer () {
       })
     }
   }
-  const wss = new WebSocketServer({ port: port })
+  const wss = new WebSocketServer({ port })
 
   wss.on('connection', function (ws, req) {
     if (req.url == null) {

--- a/test/pass-in-server.spec.ts
+++ b/test/pass-in-server.spec.ts
@@ -40,7 +40,7 @@ describe('simple echo server', () => {
       [1, 2, 3],
       // need a delay, because otherwise ws hangs up wrong.
       // otherwise use pull-goodbye.
-      (source) => map(source, async val => await new Promise(resolve => setTimeout(() => resolve(val), 10))),
+      (source) => map(source, async val => await new Promise(resolve => setTimeout(() => { resolve(val) }, 10))),
       (source) => map(ndjson.stringify(source), str => uint8ArrayFromString(str)),
       stream,
       ndjson.parse,

--- a/test/server-echo.spec.ts
+++ b/test/server-echo.spec.ts
@@ -29,7 +29,7 @@ describe('simple echo server', () => {
       [1, 2, 3],
       // need a delay, because otherwise ws hangs up wrong.
       // otherwise use pull-goodbye.
-      (source) => each(source, async () => await delay(10)),
+      (source) => each(source, async () => { await delay(10) }),
       (source) => map(ndjson.stringify(source), str => uint8ArrayFromString(str)),
       stream,
       ndjson.parse,


### PR DESCRIPTION
libp2p streams are now explicit about the types of sync/sources they provide, showing that they are `AsyncGenerator`s and not just `AsyncIterable`s.

Refs: https://github.com/achingbrain/it-stream-types/pull/45

BREAKING CHANGE: the type of the source/sink properties have changed