### PR TITLE
deps: add @types/ws to dependencies to ensure types for the version of ws are compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,10 +184,10 @@
     "iso-url": "^1.1.2",
     "it-stream-types": "^2.0.1",
     "uint8arrays": "^4.0.2",
-    "ws": "^8.4.0"
+    "ws": "^8.4.0",
+    "@types/ws": "^8.2.2"
   },
   "devDependencies": {
-    "@types/ws": "^8.2.2",
     "aegir": "^38.1.8",
     "delay": "^5.0.0",
     "it-all": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "docs": "aegir docs"
   },
   "dependencies": {
-    "@types/ws": "^8.2.2"
+    "@types/ws": "^8.2.2",
     "event-iterator": "^2.0.0",
     "iso-url": "^1.1.2",
     "it-stream-types": "^2.0.1",


### PR DESCRIPTION
We want to ensure that the types for ws are compatible where they are depended on.

See https://github.com/libp2p/js-libp2p-websockets/pull/246#issuecomment-1578833261 for reference