### PR TITLE
fix: only send data if the socket is open

### DIFF
--- a/src/sink.ts
+++ b/src/sink.ts
@@ -19,6 +19,12 @@ export default (socket: WebSocket, options: SinkOptions): Sink<Source<Uint8Array
         throw err
       }
 
+      // the ready promise resolved without error but the socket was closing so
+      // exit the loop and don't send data
+      if (socket.readyState === socket.CLOSING || socket.readyState === socket.CLOSED) {
+        break
+      }
+
       socket.send(data)
     }
 


### PR DESCRIPTION
Sometimes the read promise resolves without error, but the socket is in the `CLOSING` state.

This causes an error to be thrown so only send data if the socket is `OPEN` - if it's `CLOSING` treat it as `CLOSED` and exit the loop.

Fixes this sort of thing:

<img width="492" alt="image" src="https://github.com/alanshaw/it-ws/assets/665810/17845ed5-7815-4a8d-8ca3-6d39c82945ea">
