### PR TITLE
chore: update gh action to latest version

### DIFF
--- a/.github/workflows/js-test-and-release.yml
+++ b/.github/workflows/js-test-and-release.yml
@@ -9,7 +9,9 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   packages: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
@@ -17,9 +19,10 @@ concurrency:
 
 jobs:
   js-test-and-release:
-    uses: pl-strflt/uci/.github/workflows/js-test-and-release.yml@v0.0
+    uses: ipdxco/unified-github-workflows/.github/workflows/js-test-and-release.yml@v1.0
     secrets:
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       UCI_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   "bugs": {
     "url": "https://github.com/alanshaw/it-ws/issues"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "keywords": [
     "async",
     "iterable",


### PR DESCRIPTION
The js workflow is now in the ipdxco/unified-github-workflows org.