### PR TITLE
feat: add server ping

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
     "ws": "^8.4.0"
   },
   "devDependencies": {
+    "@types/sinon": "^17.0.3",
     "aegir": "^44.0.1",
     "delay": "^6.0.0",
     "it-all": "^3.0.1",
@@ -207,6 +208,7 @@
     "it-ndjson": "^1.0.0",
     "it-pipe": "^3.0.1",
     "p-defer": "^4.0.0",
+    "sinon": "^18.0.0",
     "wherearewe": "^2.0.1",
     "wsurl": "^1.0.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { default as duplex } from './duplex.js'
 export { default as source } from './source.js'
 export { default as sink } from './sink.js'
-export { createServer } from './server.js'
+export { createServer, type WebSocketServer } from './server.js'
 export { connect } from './client.js'

--- a/test/server-ping.spec.ts
+++ b/test/server-ping.spec.ts
@@ -1,0 +1,56 @@
+import { expect } from 'aegir/chai'
+import delay from 'delay'
+import Sinon from 'sinon'
+import { isNode, isElectronMain } from 'wherearewe'
+import * as WS from '../src/index.js'
+import WebSocket from '../src/web-socket.js'
+
+describe('ping', () => {
+  if (!(isNode || isElectronMain)) {
+    return
+  }
+
+  let server: WS.WebSocketServer
+  let client: WebSocket
+
+  afterEach(async () => {
+    if (client != null) {
+      client.close()
+    }
+
+    if (server != null) {
+      await server.close()
+    }
+  })
+
+  it('server should ping connected clients', async () => {
+    server = WS.createServer({
+      heartbeatMs: 10
+    })
+    await server.listen(55214)
+
+    client = new WebSocket('http://127.0.0.1:55214')
+    const pongSpy = Sinon.spy(client, 'pong')
+
+    await delay(200)
+
+    expect(client).to.have.property('readyState', WebSocket.OPEN)
+    expect(pongSpy).to.have.property('called', true)
+  })
+
+  it('server should disconnected unresponsive clients', async () => {
+    server = WS.createServer({
+      heartbeatMs: 10
+    })
+    await server.listen(55214)
+
+    client = new WebSocket('http://127.0.0.1:55214')
+
+    // make sure the client will not respond to a ping
+    client.pong = () => {}
+
+    await delay(200)
+
+    expect(client).to.have.property('readyState', WebSocket.CLOSED)
+  })
+})


### PR DESCRIPTION
Adds an optional `heartbeatMs` key to the server config that will ping each connected client on that interval - if they have not responded with a pong since the last interval, the client will be disconnected as described at https://www.npmjs.com/package/ws#how-to-detect-and-close-broken-connections

Fixes #113