### PR TITLE
fix(125): sink close on end

### DIFF
--- a/src/sink.ts
+++ b/src/sink.ts
@@ -28,7 +28,7 @@ export default (socket: WebSocket, options: SinkOptions): Sink<Source<Uint8Array
       socket.send(data)
     }
 
-    if (options.closeOnEnd != null && socket.readyState <= 1) {
+    if (!!options.closeOnEnd && socket.readyState <= 1) {
       await new Promise<void>((resolve, reject) => {
         socket.addEventListener('close', event => {
           if (event.wasClean || event.code === 1006) {

--- a/test/close-on-end.spec.ts
+++ b/test/close-on-end.spec.ts
@@ -6,6 +6,7 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import * as WS from '../src/index.js'
 import WebSocket from '../src/web-socket.js'
 import wsurl from './helpers/wsurl.js'
+import delay from 'delay'
 
 const endpoint = wsurl + '/echo'
 
@@ -17,6 +18,7 @@ describe('close on end', () => {
       uint8ArrayFromString('y'),
       uint8ArrayFromString('z')
     ]
+    let count = 0
 
     void pipe(
       data,
@@ -25,10 +27,22 @@ describe('close on end', () => {
 
     await pipe(
       WS.source(socket),
+      (source) => each(source, (item) => {
+        expect(item).to.be.ok()
+        count++
+
+        if (count === data.length) {
+          // verify status is closing/closed after draining
+          delay(500).then(() => {
+            expect(socket.readyState).to.be.eq(WebSocket.CLOSED)
+          })
+        }
+      }),
       drain
     )
 
     socket.close()
+    expect(count).to.be.eq(data.length)
   })
 
   it('closeOnEnd=false, stream doesn\'t close', async () => {
@@ -51,11 +65,18 @@ describe('close on end', () => {
         expect(item).to.be.ok()
         count++
 
-        if (count === 3) {
+        if (count === data.length) {
+          // verify status is open after draining
+          expect(socket.readyState).to.be.eq(WebSocket.OPEN)
           socket.close()
+          delay(500).then(() => {
+            expect(socket.readyState).to.be.eq(WebSocket.CLOSED)
+          })
         }
       }),
       drain
     )
+
+    expect(count).to.be.eq(data.length)
   })
 })

--- a/test/duplex.spec.ts
+++ b/test/duplex.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'aegir/chai'
 import delay from 'delay'
 import drain from 'it-drain'
+import each from 'it-foreach'
 import { pipe } from 'it-pipe'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import * as WS from '../src/index.js'
@@ -18,7 +19,15 @@ describe('duplex', () => {
       uint8ArrayFromString('z')
     ]
 
-    const duplex = WS.duplex(socket, { closeOnEnd: false })
+    const duplex = WS.duplex(socket, { closeOnEnd: true })
+
+    while (true) {
+      if (duplex.socket.readyState === WebSocket.OPEN) {
+        break
+      }
+
+      await delay(100)
+    }
 
     await pipe(
       data,
@@ -31,6 +40,46 @@ describe('duplex', () => {
     await duplex.close()
 
     expect(duplex.socket.readyState).to.equal(WebSocket.CLOSED)
+  })
+
+  it('should close if already open and done reading data', async () => {
+    const socket = new WebSocket(endpoint)
+    const data = [
+      uint8ArrayFromString('x'),
+      uint8ArrayFromString('y'),
+      uint8ArrayFromString('z')
+    ]
+    let count = 0
+
+    const duplex = WS.duplex(socket, { closeOnEnd: false })
+
+    while (true) {
+      if (duplex.socket.readyState === WebSocket.OPEN) {
+        break
+      }
+
+      await delay(100)
+    }
+
+    await pipe(
+      data,
+      duplex,
+      (source) => each(source, (item) => {
+        expect(item).to.be.ok()
+        count++
+
+        if (count === data.length) {
+          // verify status is open after draining
+          expect(socket.readyState).to.be.eq(WebSocket.OPEN)
+          duplex.close().then(() => {
+            expect(duplex.socket.readyState).to.equal(WebSocket.CLOSED)
+          })
+        }
+      }),
+      drain
+    )
+
+    await duplex.close()
   })
 
   it('should close if connecting', async () => {


### PR DESCRIPTION
* Update `closeOnEnd` behavior to respect `false`
* Update unit tests for close-on-end and duplex to correctly expect behavior based on `closeOnEnd`

#125 